### PR TITLE
Fix monsieurbiz_sylius_alert_message_plugin.yaml prefix value

### DIFF
--- a/monsieurbiz/sylius-alert-message-plugin/1.0/config/routes/monsieurbiz_sylius_alert_message_plugin.yaml
+++ b/monsieurbiz/sylius-alert-message-plugin/1.0/config/routes/monsieurbiz_sylius_alert_message_plugin.yaml
@@ -1,3 +1,3 @@
 monsieurbiz_sylius_alert_message_admin:
     resource: "@MonsieurBizSyliusAlertMessagePlugin/Resources/config/routing/admin.yaml"
-    prefix: /admin
+    prefix: /%sylius_admin.path_name%


### PR DESCRIPTION
To be consistent with all other recipes, let's use the Sylius parameter instead of a hardcoded value.